### PR TITLE
fix: duration was exposed in microseconds but is expected to be in seconds

### DIFF
--- a/src/core/FSV.ts
+++ b/src/core/FSV.ts
@@ -22,7 +22,7 @@ export interface FSVTrack {
   height: number
 
   /**
-   * The duration of the video in seconds.
+   * The duration of the video in microseconds.
    */
   duration: number
 

--- a/src/core/TrackDecoder.ts
+++ b/src/core/TrackDecoder.ts
@@ -39,7 +39,7 @@ export class TrackDecoder implements Video {
   }
 
   public get duration() {
-    return (this.track?.duration || 0) / 1_000_000
+    return this.track?.duration || 0
   }
 
   public get length() {
@@ -82,7 +82,7 @@ export class TrackDecoder implements Video {
   }
 
   public seek(time: number): void {
-    this.progress(time / this.duration)
+    this.progress(time / (this.duration /  1_000_000))
   }
 
   public progress(progress: number): void {

--- a/src/core/TrackDecoder.ts
+++ b/src/core/TrackDecoder.ts
@@ -39,7 +39,7 @@ export class TrackDecoder implements Video {
   }
 
   public get duration() {
-    return this.track?.duration || 0
+    return (this.track?.duration || 0) / 1_000_000
   }
 
   public get length() {


### PR DESCRIPTION
## Summary
- `Video.duration` is documented as seconds but `TrackDecoder.duration` was returning the raw microsecond value from the manifest, breaking `seek(time)` whose `time` is in seconds.
- The manifest keeps `FSVTrack.duration` in microseconds (matching WebCodecs conventions and `chunk.timestamp`); conversion to seconds now happens at the public `duration` getter boundary.
- The .seek() was expecting to receive a time in seconds