### PR TITLE
fix: adjust default encoder options depending on chosen codec

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,36 @@ conversion may fail (especially for alpha videos) if the input codec is not
 compatible with the conversion process. For VP8/VP9 input videos, you may
 need to explicitly set the input codec to `libvpx-vp8` or `libvpx-vp9`.
 
+### Encoder Options
+
+FSV uses codec-specific default encoder options optimized for fast scrubbing
+and efficient decoding:
+
+| Option | H.264 (libx264) | H.265 (libx265) |
+|:-------|:-----------------|:-----------------|
+| crf | 20 | 20 |
+| preset | slower | slower |
+| tune | fastdecode | fastdecode |
+| profile | baseline | - |
+| level | 5.1 | - |
+| gopSize | 5 | 5 |
+| maxBFrames | 0 | 0 |
+| refs | 1 | 1 |
+| pixel_format | yuv420p | yuv420p |
+
+**Performance notes:**
+- `fastdecode` tune optimizes the encoded bitstream for faster decoding
+- Low `gopSize` (5) ensures frequent keyframes for frame-accurate seeking
+- `maxBFrames: 0` avoids bidirectional frames, simplifying decoding order
+- `refs: 1` limits reference frames, reducing memory usage during decoding
+- `profile: baseline` for H.264 ensures maximum compatibility
+
+All of these values as well as other encoder options can be overridden via the
+`encoder` option of the converter.
+
+When using the cli, the `crf` and `gopSize` options can be overridden via the
+`--crf` and `--gop` arguments.
+
 ## Rendering
 
 To render a fsv video in the browser with frame-accurate scrubbing, use the

--- a/src/core/Converter.ts
+++ b/src/core/Converter.ts
@@ -44,7 +44,40 @@ import {
 
 import type { Packet } from './Packet'
 import { Muxer as FSVMuxer } from './Muxer'
-import { assertCodec, DEFAULT_CODEC, type Codec } from './Codec'
+import { assertCodec, DEFAULT_CODEC, H264, H265, type Codec } from './Codec'
+
+const DEFAULT_ENCODER_OPTIONS: Record<Codec, Partial<EncoderOptions>> = {
+  [H264]: {
+    threadCount: 0,
+    threadType: FF_THREAD_FRAME,
+    gopSize: 5,
+    maxBFrames: 0,
+    options: {
+      crf: '20',
+      preset: 'slower',
+      tune: 'fastdecode',
+      profile: 'baseline',
+      level: '5.1',
+      sc_threshold: '0',
+      refs: '1',
+      pixel_format: AV_PIX_FMT_YUV420P
+    }
+  },
+  [H265]: {
+    threadCount: 0,
+    threadType: FF_THREAD_FRAME,
+    gopSize: 5,
+    maxBFrames: 0,
+    options: {
+      crf: '20',
+      preset: 'slower',
+      tune: 'fastdecode',
+      sc_threshold: '0',
+      refs: '1',
+      pixel_format: AV_PIX_FMT_YUV420P
+    }
+  }
+}
 
 const ALPHA_SPLIT_FILTER = (
   '[0:v]split[v1][v2];[v1]format=yuv420p[color];[v2]alphaextract,format=yuv420p[alpha]'
@@ -212,7 +245,7 @@ async function transcode(source: string | Buffer, {
     logger?.info(`Initializing encoder with codec ${outputCodec}`)
     using encoder = await Encoder.create(
       outputCodec as FFEncoderCodec,
-      resolveEncoderOptions(videoStream, encoderOptions)
+      resolveEncoderOptions(videoStream, outputCodec, encoderOptions)
     )
 
     // Setting AV_CODEC_FLAG_GLOBAL_HEADER causes the encoder to place SPS/PPS
@@ -325,7 +358,7 @@ async function transcodeAlpha(source: string | Buffer, {
       throw new Error('No video stream found in input')
     }
 
-    const resolvedEncoderOptions = resolveEncoderOptions(videoStream, encoderOptions)
+    const resolvedEncoderOptions = resolveEncoderOptions(videoStream, outputCodec, encoderOptions)
 
     logger?.info(`Initializing decoder with codec ${inputCodec || '[auto]'}`)
     using decoder = await Decoder.create(
@@ -660,29 +693,18 @@ function streamDurationToMicroseconds(stream: Stream): number {
 
 function resolveEncoderOptions(
   stream: Stream,
+  codec: Codec,
   encoderOptions?: Partial<EncoderOptions>
 ): EncoderOptions {
+  const defaultEncoderOptions = DEFAULT_ENCODER_OPTIONS[codec]
+
   return {
-    threadCount: 0,
-    threadType: FF_THREAD_FRAME,
-    gopSize: 5,
-    maxBFrames: 0,
+    ...defaultEncoderOptions,
     timeBase: stream.timeBase,
     frameRate: stream.avgFrameRate,
     ...encoderOptions,
     options: {
-      ...{
-        crf: 20,
-        preset: 'slower',
-        tune: 'fastdecode',
-        profile: 'baseline',
-        level: '5.1',
-        sc_threshold: '0',
-        movflags: '+faststart',
-        refs: '1',
-        pixel_format: AV_PIX_FMT_YUV420P
-      },
-
+      ...defaultEncoderOptions?.options,
       ...encoderOptions?.options
     }
   } as EncoderOptions

--- a/tests/Converter.test.ts
+++ b/tests/Converter.test.ts
@@ -47,18 +47,7 @@ describe('Converter', () => {
 
     it('converts with libx265 output codec', async () => {
       const fsv = demux(await Converter.convert(H264_MP4_FIXTURE, {
-        outputCodec: H265,
-        encoder: {
-          options: {
-            // @todo: Adjust default encoder options depending on the chosen output codec
-            // See issue #22
-            // libx265 does not support H.264-specific profile/tune values;
-            // override them so the encoder initialises successfully.
-            profile: undefined,
-            tune: undefined,
-            preset: 'ultrafast'
-          }
-        }
+        outputCodec: H265
       }))
 
       expect(fsv.width).toBe(320)


### PR DESCRIPTION
## Summary
- Store codec-specific defaults in `DEFAULT_ENCODER_OPTIONS` map at the top of `Converter.ts`
- H.264 uses `profile:'baseline'`, `level:'5.1'`, `preset:'slower'`; H.265 uses `preset:'slower'` without profile/level
- Remove H.265 workaround from tests since defaults now work correctly out of the box
- Document encoder options and performance rationale in README

fixes #22