### PR TITLE
feat: Implement improved side effects cleaning

### DIFF
--- a/src/core/Decoder.ts
+++ b/src/core/Decoder.ts
@@ -61,6 +61,8 @@ export class Decoder implements Video {
   private alphaDecoder?: TrackDecoder
   private colorFrame?: VideoFrame
   private alphaFrame?: VideoFrame
+  private streamCancel?: () => void
+  private closed: boolean = false
 
   /**
    * Creates a new Decoder instance.
@@ -140,22 +142,29 @@ export class Decoder implements Video {
      */
     loaded(length?: number): Promise<void>
   }> {
+    this.streamCancel?.()
+    this.streamCancel = undefined
+
     const {
       fsv,
-      loaded
+      loaded,
+      cancel
     } = await Demuxer.demuxStream(reader, () => {
+      if (this.closed) return
       if (this.pendingFrame !== undefined) {
         this.colorDecoder.set(this.pendingFrame)
       }
     })
 
+    this.streamCancel = cancel
     this.alphaDecoder?.close()
     this.alphaDecoder = undefined
 
     try {
       await this.colorDecoder.load(fsv, config)
     } catch (error) {
-      await reader.cancel()
+      cancel()
+      this.streamCancel = undefined
       throw error
     }
 
@@ -196,6 +205,9 @@ export class Decoder implements Video {
    * Closes the decoder and releases all associated resources.
    */
   public close(): void {
+    this.closed = true
+    this.streamCancel?.()
+    this.streamCancel = undefined
     this.colorDecoder.close()
     this.alphaDecoder?.close()
     this.colorFrame?.close()
@@ -207,24 +219,25 @@ export class Decoder implements Video {
   }
 
   private colorCallback = (frame: VideoFrame, index: number): void => {
-    if (index === this.pendingFrame) {
-      this.colorFrame = frame
-      this.commonCallback()
-    } else {
+    if (this.closed || index !== this.pendingFrame) {
       frame.close()
+      return
     }
+    this.colorFrame = frame
+    this.commonCallback()
   }
 
   private alphaCallback = (frame: VideoFrame, index: number): void => {
-    if (index === this.pendingFrame) {
-      this.alphaFrame = frame
-      this.commonCallback()
-    } else {
+    if (this.closed || index !== this.pendingFrame) {
       frame.close()
+      return
     }
+    this.alphaFrame = frame
+    this.commonCallback()
   }
 
   private commonCallback = (): void => {
+    if (this.closed) return
     if (this.colorFrame && (!this.alphaDecoder || this.alphaFrame)) {
       this.currentFrame = this.pendingFrame
       this.callback(this.colorFrame, this.alphaFrame, this.currentFrame!)

--- a/src/core/Demuxer.ts
+++ b/src/core/Demuxer.ts
@@ -110,6 +110,12 @@ async function demuxStream(
    *          been loaded.
    */
   loaded(length?: number): Promise<void>
+
+  /**
+   * Cancels the stream, stopping the background read loop and rejecting any
+   * pending `loaded()` promises.
+   */
+  cancel(): void
 }> {
   const buffer = createStreamBuffer()
 
@@ -163,11 +169,23 @@ async function demuxStream(
 
   const queue = createStreamQueue(fsv)
 
+  let cancelled = false
+
+  const cancel = () => {
+    if (cancelled) return
+    cancelled = true
+    reader.cancel().catch(() => {})
+    buffer.flush()
+    queue.cancel(new Error('FSV stream cancelled'))
+  }
+
   let keyIndex: number = 0
   let loadingFrameIndex: number = 0
   let loadingFrame: ManifestFrame | undefined = manifest.frames[0]
 
   const writeFrames = () => {
+    if (cancelled) return
+
     let loadedFrame = false
 
     while (
@@ -205,13 +223,13 @@ async function demuxStream(
     }
   }
 
-  (async () => {
+  ;(async () => {
     writeFrames()
 
-    while (true) {
+    while (!cancelled) {
       const { done, value } = await reader.read()
 
-      if (done) {
+      if (done || cancelled) {
         break
       }
 
@@ -222,7 +240,8 @@ async function demuxStream(
 
   return {
     fsv,
-    loaded: queue.loaded
+    loaded: queue.loaded,
+    cancel
   }
 }
 
@@ -313,19 +332,24 @@ function createStreamBuffer() {
 }
 
 function createStreamQueue(fsv: FSV) {
-  const queue = new Map<() => void, number>()
+  const queue = new Map<() => void, { length: number; reject: (error: Error) => void }>()
+  let cancelError: Error | undefined
 
   return {
     loaded(length: number = fsv.length) {
+      if (cancelError) {
+        return Promise.reject(cancelError)
+      }
+
       return length <= fsv.frames.length
         ? Promise.resolve()
-        : new Promise<void>(resolve => queue.set(resolve, length))
+        : new Promise<void>((resolve, reject) => queue.set(resolve, { length, reject }))
     },
 
     update() {
       const trash: (() => void)[] = []
 
-      for (const [resolve, length] of queue) {
+      for (const [resolve, { length }] of queue) {
         if (length <= fsv.frames.length) {
           resolve()
           trash.push(resolve)
@@ -335,6 +359,16 @@ function createStreamQueue(fsv: FSV) {
       for (const resolve of trash) {
         queue.delete(resolve)
       }
+    },
+
+    cancel(error: Error) {
+      cancelError = error
+
+      for (const [, { reject }] of queue) {
+        reject(error)
+      }
+
+      queue.clear()
     }
   }
 }

--- a/src/core/Renderer.ts
+++ b/src/core/Renderer.ts
@@ -54,14 +54,15 @@ export class Renderer implements Video {
 
   private gl: WebGL2RenderingContext
   private decoder: Decoder
-  private buffer: WebGLBuffer
-  private vertexArray: WebGLVertexArrayObject
+  private buffer?: WebGLBuffer
+  private vertexArray?: WebGLVertexArrayObject
   private vertexShader?: WebGLShader
   private fragmentShader?: WebGLShader
   private program?: WebGLProgram
-  private colorTexture: WebGLTexture
+  private colorTexture?: WebGLTexture
   private alphaTexture?: WebGLTexture
   private currentPremultiplyAlpha: boolean
+  private closed: boolean = false
 
   public get width() {
     return this.decoder.width
@@ -156,6 +157,8 @@ export class Renderer implements Video {
     data: ArrayBuffer | string,
     config?: Partial<VideoDecoderConfig>
   ): Promise<void> {
+    if (this.closed) throw new Error('Renderer is closed')
+
     if (typeof data === 'string') {
       const response = await fetch(data)
 
@@ -226,14 +229,17 @@ export class Renderer implements Video {
   }
 
   public seek(time: number): void {
+    if (this.closed) throw new Error('Renderer is closed')
     this.decoder.seek(time)
   }
 
   public progress(progress: number): void {
+    if (this.closed) throw new Error('Renderer is closed')
     this.decoder.progress(progress)
   }
 
   public set(index: number): void {
+    if (this.closed) throw new Error('Renderer is closed')
     this.decoder.set(index)
   }
 
@@ -241,16 +247,30 @@ export class Renderer implements Video {
    * Closes the renderer and releases all associated resources.
    */
   public close(): void {
+    if (this.closed) return
+    this.closed = true
+
     this.decoder.close()
 
     this.program && this.gl.deleteProgram(this.program)
     this.vertexShader && this.gl.deleteShader(this.vertexShader)
     this.fragmentShader && this.gl.deleteShader(this.fragmentShader)
 
-    this.gl.deleteTexture(this.colorTexture)
+    this.colorTexture && this.gl.deleteTexture(this.colorTexture)
     this.alphaTexture && this.gl.deleteTexture(this.alphaTexture)
 
-    this.gl.deleteBuffer(this.buffer)
+    this.buffer && this.gl.deleteBuffer(this.buffer)
+    this.vertexArray && this.gl.deleteVertexArray(this.vertexArray)
+
+    this.program = undefined
+    this.vertexShader = undefined
+    this.fragmentShader = undefined
+    this.colorTexture = undefined
+    this.alphaTexture = undefined
+    this.buffer = undefined
+    this.vertexArray = undefined
+
+    this.gl.getExtension('WEBGL_lose_context')?.loseContext()
   }
 
   /**
@@ -260,6 +280,8 @@ export class Renderer implements Video {
    * changed, or if the program or textures need to be recreated for any reason.
    */
   public initialize() {
+    if (this.closed) throw new Error('Renderer is closed')
+
     if (
       this.program &&
       this.alpha === this.decoder.alpha &&
@@ -319,7 +341,7 @@ export class Renderer implements Video {
     this.gl.clearColor(0, 0, 0, 0)
     this.gl.clear(this.gl.COLOR_BUFFER_BIT)
     this.gl.useProgram(this.program!)
-    this.gl.bindVertexArray(this.vertexArray)
+    this.gl.bindVertexArray(this.vertexArray ?? null)
     this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 3)
   }
 

--- a/src/core/TrackDecoder.ts
+++ b/src/core/TrackDecoder.ts
@@ -25,6 +25,7 @@ export class TrackDecoder implements Video {
   public currentFrame?: number
   public pendingFrame?: number
   public readonly alpha = false
+  private closed: boolean = false
 
   private track?: FSVTrack
   private config?: VideoDecoderConfig
@@ -72,6 +73,14 @@ export class TrackDecoder implements Video {
     track: FSVTrack,
     config?: Partial<VideoDecoderConfig>,
   ): Promise<void> {
+    if (this.closed) {
+      this.decoder = new VideoDecoder({
+        output: this.output,
+        error: this.error
+      })
+      this.closed = false
+    }
+
     this.config = await TrackDecoder.config(track, config)
     this.track = track
     this.currentFrame = undefined
@@ -90,6 +99,7 @@ export class TrackDecoder implements Video {
   }
 
   public set(index: number): void {
+    if (this.closed) return
     index = Math.max(0, Math.min(this.length, index))
 
     if (index === this.currentFrame) {
@@ -105,7 +115,7 @@ export class TrackDecoder implements Video {
     }
 
     if (this.decoder.state === 'closed') {
-      this.decoder.configure(this.config!)
+      return
     }
 
     if (
@@ -131,6 +141,7 @@ export class TrackDecoder implements Video {
    * Closes the decoder and releases all associated resources.
    */
   public close(): void {
+    this.closed = true
     this.currentFrame = undefined
     this.pendingFrame = undefined
     this.track = undefined
@@ -138,7 +149,12 @@ export class TrackDecoder implements Video {
   }
 
   private output = (frame: VideoFrame): void => {
-    const index = this.track!.indices.get(frame.timestamp)!
+    if (this.closed || !this.track) {
+      frame.close()
+      return
+    }
+
+    const index = this.track.indices.get(frame.timestamp)!
 
     if (this.pendingFrame === index) {
       this.currentFrame = index

--- a/tests/Demuxer.test.ts
+++ b/tests/Demuxer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 
 import { Muxer } from '../src/core/Muxer'
 import { Demuxer } from '../src/core/Demuxer'
@@ -146,6 +146,54 @@ describe('Demuxer', () => {
       )
     })
   })
+
+  describe('demuxStream cancel()', () => {
+    it('cancel() is included in the return value', async () => {
+      const buf = makeNonAlphaFSV(5)
+      const { reader } = makeHangingReader(buf)
+      const result = await Demuxer.demuxStream(reader)
+      expect(typeof result.cancel).toBe('function')
+      result.cancel()
+    })
+
+    it('cancel() is idempotent', async () => {
+      const buf = makeNonAlphaFSV(5)
+      const { reader } = makeHangingReader(buf)
+      const { cancel } = await Demuxer.demuxStream(reader)
+      expect(() => { cancel(); cancel() }).not.toThrow()
+    })
+
+    it('pending loaded() promises reject when cancel() is called', async () => {
+      const buf = makeNonAlphaFSV(5)
+      const { reader } = makeHangingReader(buf)
+      const { loaded, cancel } = await Demuxer.demuxStream(reader)
+
+      const promise = loaded()
+      cancel()
+
+      await expect(promise).rejects.toThrow('FSV stream cancelled')
+    })
+
+    it('loaded() rejects immediately when called after cancel()', async () => {
+      const buf = makeNonAlphaFSV(5)
+      const { reader } = makeHangingReader(buf)
+      const { loaded, cancel } = await Demuxer.demuxStream(reader)
+
+      cancel()
+
+      await expect(loaded()).rejects.toThrow('FSV stream cancelled')
+    })
+
+    it('cancel() invokes reader.cancel()', async () => {
+      const buf = makeNonAlphaFSV(5)
+      const { reader, readerCancel } = makeHangingReader(buf)
+      const { cancel } = await Demuxer.demuxStream(reader)
+
+      cancel()
+
+      expect(readerCancel).toHaveBeenCalledOnce()
+    })
+  })
 })
 
 const config: VideoDecoderConfig = {
@@ -192,4 +240,40 @@ function bufferToStream(buf: Buffer): ReadableStreamDefaultReader<Uint8Array<Arr
     }
   })
   return stream.getReader()
+}
+
+/**
+ * Returns a reader that yields only the FSV header + manifest bytes, then
+ * blocks indefinitely until cancel() is called. This lets cancel() tests run
+ * without triggering EncodedVideoChunk construction (frame data is never sent).
+ */
+function makeHangingReader(buf: Buffer) {
+  const manifestLength = buf.readUInt32LE(4)
+  const headerAndManifest = buf.buffer.slice(
+    buf.byteOffset,
+    buf.byteOffset + 8 + manifestLength
+  ) as ArrayBuffer
+  const initialChunk = new Uint8Array(headerAndManifest) as Uint8Array<ArrayBuffer>
+
+  let unblockRead: () => void
+  const blocked = new Promise<void>(resolve => { unblockRead = resolve! })
+
+  const readerCancel = vi.fn(() => {
+    unblockRead()
+    return Promise.resolve()
+  })
+
+  let readCount = 0
+  const reader = {
+    read(): Promise<{ done: false; value: Uint8Array<ArrayBuffer> } | { done: true; value: undefined }> {
+      if (++readCount === 1) {
+        return Promise.resolve({ done: false as const, value: initialChunk })
+      }
+      return blocked.then(() => ({ done: true as const, value: undefined }))
+    },
+    cancel: readerCancel,
+    releaseLock: () => {}
+  } as unknown as ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>
+
+  return { reader, readerCancel }
 }


### PR DESCRIPTION
I faced some performance issues after few Renderer creation / closing.
Tried to improve it a bit. Might contain some AI slope. 


## Summary

- **Cancellable stream loop** — `Demuxer.demuxStream` now returns a `cancel()` function. Calling it stops the background read loop, cancels the underlying reader, and rejects any pending `loaded()` promises. Previously the loop ran to completion regardless of whether the consumer was still alive.

- **Decoder tears down its stream on close** — `Decoder` stores the `cancel` from `demuxStream` and calls it in `close()` (and before starting a new `loadStream`). The `onLoadFrames` callback and all frame callbacks guard against `closed`, so no frames are processed and no `VideoDecoder` is touched after teardown.

- **No more VideoDecoder resurrection** — `TrackDecoder.set()` now returns immediately when closed instead of reconfiguring a closed `VideoDecoder`. `TrackDecoder.load()` re-creates the decoder lazily when reloading after a close, keeping the `load → close → load` cycle working. `output()` also guards against being called post-close.

- **Complete and idempotent `Renderer.close()`** — The VAO is now deleted, all GL handles are nulled after deletion, and `WEBGL_lose_context.loseContext()` is called to immediately free the WebGL2 context slot (browsers cap active contexts at ~8–16; exceeding this caused the freezing). `close()` is safe to call multiple times. Public methods (`load`, `loadStream`, `seek`, `progress`, `set`, `initialize`) throw `'Renderer is closed'` after teardown.