### PR TITLE
fix: restore closed video decoders

### DIFF
--- a/src/core/TrackDecoder.ts
+++ b/src/core/TrackDecoder.ts
@@ -53,11 +53,7 @@ export class TrackDecoder implements Video {
    */
   public constructor(callback: TrackDecoderCallback) {
     this.callback = callback
-
-    this.decoder = new VideoDecoder({
-      output: this.output,
-      error: this.error
-    })
+    this.decoder = this.createDecoder()
   }
 
   /**
@@ -77,7 +73,12 @@ export class TrackDecoder implements Video {
     this.currentFrame = undefined
     this.pendingFrame = undefined
 
-    this.decoder.reset()
+    if (this.decoder.state === 'closed') {
+      this.decoder = this.createDecoder()
+    } else {
+      this.decoder.reset()
+    }
+
     this.decoder.configure(this.config)
   }
 
@@ -105,7 +106,9 @@ export class TrackDecoder implements Video {
     }
 
     if (this.decoder.state === 'closed') {
+      this.decoder = this.createDecoder()
       this.decoder.configure(this.config!)
+      this.currentFrame = undefined
     }
 
     if (
@@ -150,6 +153,13 @@ export class TrackDecoder implements Video {
 
   private error = (error: unknown): void => {
     console.error('FSV', error)
+  }
+
+  private createDecoder(): VideoDecoder {
+    return new VideoDecoder({
+      output: this.output,
+      error: this.error
+    })
   }
 
   private static async config(

--- a/tests/TrackDecoder.test.ts
+++ b/tests/TrackDecoder.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+
+import { TrackDecoder } from '../src/core/TrackDecoder'
+import type { FSVTrack } from '../src/core/FSV'
+
+const originalVideoDecoder = globalThis.VideoDecoder
+
+describe('TrackDecoder', () => {
+  beforeEach(() => {
+    MockVideoDecoder.instances = []
+    globalThis.VideoDecoder = MockVideoDecoder as unknown as typeof VideoDecoder
+  })
+
+  afterAll(() => {
+    if (originalVideoDecoder) {
+      globalThis.VideoDecoder = originalVideoDecoder
+    } else {
+      Reflect.deleteProperty(globalThis, 'VideoDecoder')
+    }
+  })
+
+  it('creates a new VideoDecoder when the current decoder was closed', async () => {
+    const decoder = new TrackDecoder(() => {})
+    await decoder.load(makeTrack())
+
+    const initialDecoder = MockVideoDecoder.instances[0]
+    initialDecoder.state = 'closed'
+
+    decoder.set(0)
+
+    expect(MockVideoDecoder.instances).toHaveLength(2)
+    expect(initialDecoder.decodedTimestamps).toEqual([])
+    expect(MockVideoDecoder.instances[1].decodedTimestamps).toEqual([0])
+  })
+
+  it('replays from the key frame after recreating a closed decoder', async () => {
+    const decoder = new TrackDecoder(() => {})
+    await decoder.load(makeTrack())
+
+    decoder.currentFrame = 1
+    MockVideoDecoder.instances[0].state = 'closed'
+
+    decoder.set(2)
+
+    expect(MockVideoDecoder.instances[1].decodedTimestamps).toEqual([0, 1, 2])
+  })
+})
+
+const config: VideoDecoderConfig = {
+  codec: 'avc1.42001f',
+  codedWidth: 320,
+  codedHeight: 240,
+  optimizeForLatency: true
+}
+
+class MockVideoDecoder {
+  static instances: MockVideoDecoder[] = []
+
+  state: 'unconfigured' | 'configured' | 'closed' = 'unconfigured'
+  decodeQueueSize = 0
+  decodedTimestamps: number[] = []
+
+  constructor(_init: VideoDecoderInit) {
+    MockVideoDecoder.instances.push(this)
+  }
+
+  configure(_config: VideoDecoderConfig): void {
+    if (this.state === 'closed') {
+      throw new Error('Cannot configure a closed decoder')
+    }
+
+    this.state = 'configured'
+  }
+
+  reset(): void {
+    if (this.state === 'closed') {
+      throw new Error('Cannot reset a closed decoder')
+    }
+
+    this.decodeQueueSize = 0
+  }
+
+  decode(chunk: EncodedVideoChunk): void {
+    if (this.state !== 'configured') {
+      throw new Error('Cannot decode with an unconfigured decoder')
+    }
+
+    this.decodedTimestamps.push(chunk.timestamp)
+  }
+
+  close(): void {
+    this.state = 'closed'
+  }
+
+  static async isConfigSupported(
+    config: VideoDecoderConfig
+  ): Promise<VideoDecoderSupport> {
+    return { config, supported: true }
+  }
+}
+
+function makeTrack(length = 3): FSVTrack {
+  const indices = new Map<number, number>()
+  const frames = Array.from({ length }, (_, index) => {
+    indices.set(index, index)
+
+    return {
+      keyIndex: 0,
+      chunk: new EncodedVideoChunk({
+        type: index === 0 ? 'key' : 'delta',
+        timestamp: index,
+        data: new Uint8Array([index])
+      })
+    }
+  })
+
+  return {
+    config,
+    width: 320,
+    height: 240,
+    duration: length,
+    length,
+    indices,
+    frames
+  }
+}


### PR DESCRIPTION
## Summary
- Recreate TrackDecoder's VideoDecoder when Chrome closes it after inactivity.
- Reset cached frame position after recovery so decoding resumes from the nearest keyframe.
- Add regression tests covering closed decoder recreation and keyframe replay.

Closes #33